### PR TITLE
Auto-closing emoji panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -121,17 +121,32 @@
         const messages = document.getElementById('messages');
         const emojiBtn = document.getElementById('emoji-btn');
         const emojiPanel = document.getElementById('emoji-panel');
+        let emojiTimer = null;
+
+        const startAutoCloseTimer = () => {
+            clearTimeout(emojiTimer);
+            emojiTimer = setTimeout(() => {
+                emojiPanel.classList.add('hidden');
+                emojiTimer = null;
+            }, 2000);
+        };
         let nickname = null;
 
         emojiBtn.addEventListener('click', () => {
-            emojiPanel.classList.toggle('hidden');
+            if (emojiPanel.classList.contains('hidden')) {
+                emojiPanel.classList.remove('hidden');
+                startAutoCloseTimer();
+            } else {
+                emojiPanel.classList.add('hidden');
+                clearTimeout(emojiTimer);
+            }
         });
 
         emojiPanel.addEventListener('click', (e) => {
             if (e.target.classList.contains('emoji')) {
                 input.value += e.target.textContent;
-                emojiPanel.classList.add('hidden');
                 input.focus();
+                startAutoCloseTimer();
             }
         });
 


### PR DESCRIPTION
## Summary
- toggle emoji panel when clicking the emoji icon
- automatically hide the panel after 2 seconds if open
- keep the panel open for up to 2 seconds after an emoji is chosen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686a32b449348330b7656e7c81a8a3a4